### PR TITLE
GMOD-47 - Add full compatibility with Discord emotes

### DIFF
--- a/lua/autorun/sh_schat.lua
+++ b/lua/autorun/sh_schat.lua
@@ -82,10 +82,15 @@ local function normaliseEmotes(str)
 		end
 
 		local emote, isCustom = SChat.Settings:GetEmojiInfo(emoteId)
-		if isCustom and not str:find("^<:[%w_%-]+:%d+>", startIdx - 1) then
+		if
+			isCustom
+			and not str:find("^<:[%w_%-]+:%d+>", startIdx - 1)
+			and not str:find("^<a:[%w_%-]+:%d+>", startIdx - 2)
+		then
 			str = string.format(
-				"%s<:%s:%s>%s",
+				"%s<%s:%s:%s>%s",
 				str:sub(1, startIdx - 1),
+				emote.isAnimated and "a" or "",
 				emote.id,
 				emote.numericId,
 				str:sub(endIdx + 1)

--- a/lua/autorun/sh_schat.lua
+++ b/lua/autorun/sh_schat.lua
@@ -20,10 +20,6 @@ function SChat:CanSetServerTheme(ply)
 	return ply:IsSuperAdmin()
 end
 
-function SChat:CanSetServerEmojis(ply)
-	return ply:IsSuperAdmin()
-end
-
 function SChat:CanSetChatTags(ply)
 	return ply:IsSuperAdmin()
 end

--- a/lua/autorun/sh_schat.lua
+++ b/lua/autorun/sh_schat.lua
@@ -69,6 +69,33 @@ local trimLookup = {
 	[utf8.char(0x2067)] = "", -- Right-To-Left Isolate
 }
 
+--- Normalises custom emotes to the Discord format
+---@param str string
+---@return string
+local function normaliseEmotes(str)
+	local startIdx, endIdx, emoteId
+
+	while true do
+		startIdx, endIdx, emoteId = str:find(":([%w_%-]+):", endIdx)
+		if not startIdx or not endIdx then
+			break
+		end
+
+		local emote, isCustom = SChat.Settings:GetEmojiInfo(emoteId)
+		if isCustom and not str:find("^<:[%w_%-]+:%d+>", startIdx - 1) then
+			str = string.format(
+				"%s<:%s:%s>%s",
+				str:sub(1, startIdx - 1),
+				emote.id,
+				emote.numericId,
+				str:sub(endIdx + 1)
+			)
+		end
+	end
+
+	return str
+end
+
 function SChat.CleanupString(str)
 	if not str then
 		return ""
@@ -95,6 +122,8 @@ function SChat.CleanupString(str)
 			return "\n"
 		end
 	end)
+
+	str = normaliseEmotes(str)
 
 	return str:Trim()
 end

--- a/lua/schat/cl_chatbox.lua
+++ b/lua/schat/cl_chatbox.lua
@@ -515,8 +515,8 @@ function SChatBox:Init()
 		self:OnImageHover(url, isHovering)
 	end)
 
-	self:AddInternalCallback("OnSelectEmoji", function(id)
-		self:OnSelectEmoji(id)
+	self:AddInternalCallback("OnSelectEmoji", function(id, numericId)
+		self:OnSelectEmoji(id, numericId)
 	end)
 
 	self:AddInternalCallback("OnRightClick", function(data, isLink, steamId64)
@@ -659,6 +659,6 @@ end
 
 function SChatBox:OnPressEnter() end
 function SChatBox:OnImageHover(_url, _isHovering) end
-function SChatBox:OnSelectEmoji() end
+function SChatBox:OnSelectEmoji(_id, _numericId) end
 
 vgui.Register("SChatBox", SChatBox, "DHTML")

--- a/lua/schat/cl_chatbox.lua
+++ b/lua/schat/cl_chatbox.lua
@@ -515,9 +515,12 @@ function SChatBox:Init()
 		self:OnImageHover(url, isHovering)
 	end)
 
-	self:AddInternalCallback("OnSelectEmoji", function(id, numericId)
-		self:OnSelectEmoji(id, numericId)
-	end)
+	self:AddInternalCallback(
+		"OnSelectEmoji",
+		function(id, numericId, isAnimated)
+			self:OnSelectEmoji(id, numericId, isAnimated)
+		end
+	)
 
 	self:AddInternalCallback("OnRightClick", function(data, isLink, steamId64)
 		if SChat.isOpen then
@@ -659,6 +662,6 @@ end
 
 function SChatBox:OnPressEnter() end
 function SChatBox:OnImageHover(_url, _isHovering) end
-function SChatBox:OnSelectEmoji(_id, _numericId) end
+function SChatBox:OnSelectEmoji(_id, _numericId, _isAnimated) end
 
 vgui.Register("SChatBox", SChatBox, "DHTML")

--- a/lua/schat/cl_interface.lua
+++ b/lua/schat/cl_interface.lua
@@ -83,10 +83,12 @@ function SChat:CreatePanels()
 	self.chatBox:DockMargin(0, -24, 0, 0)
 	self.chatBox:UpdateEmojiPanel()
 
-	self.chatBox.OnSelectEmoji = function(_, id, numericId)
+	self.chatBox.OnSelectEmoji = function(_, id, numericId, isAnimated)
 		self:AppendAtCaret(
 			string.format(
-				numericId == nil and ":%s:" or "<:%s:%s>",
+				numericId == nil and ":%s:"
+					or isAnimated and "<a:%s:%s>"
+					or "<:%s:%s>",
 				id,
 				numericId
 			)

--- a/lua/schat/cl_interface.lua
+++ b/lua/schat/cl_interface.lua
@@ -83,8 +83,14 @@ function SChat:CreatePanels()
 	self.chatBox:DockMargin(0, -24, 0, 0)
 	self.chatBox:UpdateEmojiPanel()
 
-	self.chatBox.OnSelectEmoji = function(_, id)
-		self:AppendAtCaret(":" .. id .. ":")
+	self.chatBox.OnSelectEmoji = function(_, id, numericId)
+		self:AppendAtCaret(
+			string.format(
+				numericId == nil and ":%s:" or "<:%s:%s>",
+				id,
+				numericId
+			)
+		)
 	end
 
 	self.chatBox.OnPressEnter = function()
@@ -454,14 +460,6 @@ This means that no matter which site they come from, you will load it, and it CA
 		self.frame:SetPos(Settings:GetDefaultPosition())
 	end)
 
-	if self:CanSetServerEmojis(LocalPlayer()) then
-		optionsMenu
-			:AddOption("[Admin] Custom Emojis...", function()
-				Settings:ShowServerEmojisPanel()
-			end)
-			:SetIcon("icon16/emoticon_tongue.png")
-	end
-
 	if self:CanSetChatTags(LocalPlayer()) then
 		optionsMenu
 			:AddOption("[Admin] Chat Tags...", function()
@@ -792,8 +790,8 @@ net.Receive("schat.set_emojis", function()
 		data = util.JSONToTable(data)
 
 		if data then
-			for _, v in ipairs(data) do
-				Settings:AddOnlineEmoji(v[1], v[2])
+			for _, emoji in ipairs(data) do
+				Settings:AddOnlineEmoji(emoji)
 			end
 		else
 			SChat.PrintF("Failed to parse emojis from the server!")

--- a/lua/schat/cl_js.lua
+++ b/lua/schat/cl_js.lua
@@ -189,16 +189,17 @@ function SChat:GenerateEmojiList()
 			for _, emoji in ipairs(cat.emojis) do
 				local isBuiltin = type(emoji) == "string"
 
-				local id = isBuiltin and emoji or emoji[1]
+				local id = isBuiltin and emoji or emoji.id
 				local src = isBuiltin
 						and "asset://garrysmod/materials/icon72/" .. emoji .. ".png"
-					or emoji[2]
+					or emoji.uri
+				local numericId = isBuiltin and emoji.numericId or nil
 
 				lines[#lines + 1] = [[
                     var elEmoji = document.createElement('img');
                     elEmoji.src = ']] .. SafeString(src) .. [[';
                     elEmoji.className = 'emoji-button';
-                    elEmoji.onclick = function(){ SChatBox.OnSelectEmoji(']] .. id .. [[') };
+                    elEmoji.onclick = function(){ SChatBox.OnSelectEmoji(']] .. id .. [[', ]] .. numericId .. [[) };
                     elEmojiPanel.appendChild(elEmoji);
                 ]]
 			end
@@ -310,7 +311,8 @@ JSBuilder.builders["player"] = function(val, color, font)
 end
 
 JSBuilder.builders["emoji"] = function(val, color, font)
-	local path, isOnline = SChat.Settings:GetEmojiInfo(val:sub(2, -2))
+	local _, _, emojiId = string.find(val, "<:(.+):")
+	local path, isOnline = SChat.Settings:GetEmojiInfo(emojiId)
 
 	if path then
 		if not isOnline then

--- a/lua/schat/cl_js.lua
+++ b/lua/schat/cl_js.lua
@@ -193,7 +193,7 @@ function SChat:GenerateEmojiList()
 				local src = isBuiltin
 						and "asset://garrysmod/materials/icon72/" .. emoji .. ".png"
 					or emoji.uri
-				local numericId = isBuiltin and emoji.numericId or nil
+				local numericId = isBuiltin and emoji.numericId or "nil"
 
 				lines[#lines + 1] = [[
                     var elEmoji = document.createElement('img');

--- a/lua/schat/cl_js.lua
+++ b/lua/schat/cl_js.lua
@@ -313,12 +313,10 @@ end
 
 JSBuilder.builders["emoji"] = function(val, color, font)
 	local _, _, emojiId = string.find(val, "<?:(.+):")
-	local path, isOnline = SChat.Settings:GetEmojiInfo(emojiId)
+	local emoji, isOnline = SChat.Settings:GetEmojiInfo(emojiId)
 
-	if path then
-		if not isOnline then
-			path = "asset://garrysmod/" .. path
-		end
+	if emoji then
+		local path = isOnline and emoji.uri or "asset://garrysmod/" .. emoji
 
 		return JSBuilder:CreateImage(path, nil, "emoji", val)
 	end

--- a/lua/schat/cl_js.lua
+++ b/lua/schat/cl_js.lua
@@ -193,7 +193,7 @@ function SChat:GenerateEmojiList()
 				local src = isBuiltin
 						and "asset://garrysmod/materials/icon72/" .. emoji .. ".png"
 					or emoji.uri
-				local numericId = isBuiltin and emoji.numericId or "nil"
+				local numericId = isBuiltin and emoji.numericId or "undefined"
 
 				lines[#lines + 1] = [[
                     var elEmoji = document.createElement('img');

--- a/lua/schat/cl_js.lua
+++ b/lua/schat/cl_js.lua
@@ -193,7 +193,8 @@ function SChat:GenerateEmojiList()
 				local src = isBuiltin
 						and "asset://garrysmod/materials/icon72/" .. emoji .. ".png"
 					or emoji.uri
-				local numericId = isBuiltin and "undefined" or emoji.numericId
+				local numericId = isBuiltin and "undefined"
+					or string.format("'%s'", emoji.numericId)
 
 				lines[#lines + 1] = [[
                     var elEmoji = document.createElement('img');

--- a/lua/schat/cl_js.lua
+++ b/lua/schat/cl_js.lua
@@ -312,7 +312,7 @@ JSBuilder.builders["player"] = function(val, color, font)
 end
 
 JSBuilder.builders["emoji"] = function(val, color, font)
-	local _, _, emojiId = string.find(val, "<:(.+):")
+	local _, _, emojiId = string.find(val, "<?:(.+):")
 	local path, isOnline = SChat.Settings:GetEmojiInfo(emojiId)
 
 	if path then

--- a/lua/schat/cl_js.lua
+++ b/lua/schat/cl_js.lua
@@ -195,12 +195,15 @@ function SChat:GenerateEmojiList()
 					or emoji.uri
 				local numericId = isBuiltin and "undefined"
 					or string.format("'%s'", emoji.numericId)
+				local isAnimated = (not isBuiltin and emoji.isAnimated)
+						and "true"
+					or "false"
 
 				lines[#lines + 1] = [[
                     var elEmoji = document.createElement('img');
                     elEmoji.src = ']] .. SafeString(src) .. [[';
                     elEmoji.className = 'emoji-button';
-                    elEmoji.onclick = function(){ SChatBox.OnSelectEmoji(']] .. id .. [[', ]] .. numericId .. [[) };
+                    elEmoji.onclick = function(){ SChatBox.OnSelectEmoji(']] .. id .. [[', ]] .. numericId .. [[, ]] .. isAnimated .. [[) };
                     elEmojiPanel.appendChild(elEmoji);
                 ]]
 			end
@@ -313,6 +316,10 @@ end
 
 JSBuilder.builders["emoji"] = function(val, color, font)
 	local _, _, emojiId = string.find(val, "<?:(.+):")
+	if not emojiId then
+		_, _, emojiId = string.find(val, "<a:(.+):")
+	end
+
 	local emoji, isOnline = SChat.Settings:GetEmojiInfo(emojiId)
 
 	if emoji then

--- a/lua/schat/cl_js.lua
+++ b/lua/schat/cl_js.lua
@@ -193,7 +193,7 @@ function SChat:GenerateEmojiList()
 				local src = isBuiltin
 						and "asset://garrysmod/materials/icon72/" .. emoji .. ".png"
 					or emoji.uri
-				local numericId = isBuiltin and emoji.numericId or "undefined"
+				local numericId = isBuiltin and "undefined" or emoji.numericId
 
 				lines[#lines + 1] = [[
                     var elEmoji = document.createElement('img');

--- a/lua/schat/cl_parser.lua
+++ b/lua/schat/cl_parser.lua
@@ -21,7 +21,7 @@ local rangeTypes = {
 	{ type = "color", pattern = "<%d+,%d+,%d+>" },
 	{ type = "rainbow", pattern = "%$%$[^%c]+%$%$" },
 	{ type = "advert", pattern = "%[%[[^%c]+%]%]" },
-	{ type = "emoji", pattern = ":[%w_%-]+:" },
+	{ type = "emoji", pattern = "<:[%w_%-]+:%d+>" },
 	{ type = "spoiler", pattern = "||[^%c]-[^|]*||" },
 	{ type = "code_line", pattern = "`[^%c]+[`]*`" },
 	{ type = "code", pattern = "{{[^%z]-[^}}]*}}" },

--- a/lua/schat/cl_parser.lua
+++ b/lua/schat/cl_parser.lua
@@ -21,7 +21,7 @@ local rangeTypes = {
 	{ type = "color", pattern = "<%d+,%d+,%d+>" },
 	{ type = "rainbow", pattern = "%$%$[^%c]+%$%$" },
 	{ type = "advert", pattern = "%[%[[^%c]+%]%]" },
-	{ type = "emoji", pattern = "<:[%w_%-]+:%d+>", priority = true },
+	{ type = "emoji", pattern = "<a?:[%w_%-]+:%d+>", priority = true },
 	{ type = "emoji", pattern = ":[%w_%-]+:" },
 	{ type = "spoiler", pattern = "||[^%c]-[^|]*||" },
 	{ type = "code_line", pattern = "`[^%c]+[`]*`" },

--- a/lua/schat/cl_settings.lua
+++ b/lua/schat/cl_settings.lua
@@ -128,7 +128,12 @@ function Settings:AddOnlineEmoji(emoji)
 
 	table.insert(
 		emojis,
-		{ id = emoji.id, uri = emoji.uri, numericId = emoji.numericId }
+		{
+			id = emoji.id,
+			uri = emoji.uri,
+			numericId = emoji.numericId,
+			isAnimated = emoji.isAnimated,
+		}
 	)
 end
 

--- a/lua/schat/cl_settings.lua
+++ b/lua/schat/cl_settings.lua
@@ -105,7 +105,7 @@ function Settings:SetWhitelistEnabled(enabled)
 end
 
 -- Returns the properties of a emoji.
--- path, isOnline = Settings:GetEmojiInfo(id)
+-- path|emoji, isOnline = Settings:GetEmojiInfo(id)
 function Settings:GetEmojiInfo(id)
 	for _, cat in ipairs(self.emojiCategories) do
 		for _, emoji in ipairs(cat.emojis) do
@@ -115,7 +115,7 @@ function Settings:GetEmojiInfo(id)
 				end
 			else
 				if id == emoji.id then
-					return emoji.uri, true
+					return emoji, true
 				end
 			end
 		end

--- a/lua/schat/cl_settings.lua
+++ b/lua/schat/cl_settings.lua
@@ -126,15 +126,12 @@ end
 function Settings:AddOnlineEmoji(emoji)
 	local emojis = self.emojiCategories[1].emojis
 
-	table.insert(
-		emojis,
-		{
-			id = emoji.id,
-			uri = emoji.uri,
-			numericId = emoji.numericId,
-			isAnimated = emoji.isAnimated,
-		}
-	)
+	table.insert(emojis, {
+		id = emoji.id,
+		uri = emoji.uri,
+		numericId = emoji.numericId,
+		isAnimated = emoji.isAnimated,
+	})
 end
 
 function Settings:ClearCustomEmojis()

--- a/lua/schat/cl_settings.lua
+++ b/lua/schat/cl_settings.lua
@@ -108,14 +108,14 @@ end
 -- path, isOnline = Settings:GetEmojiInfo(id)
 function Settings:GetEmojiInfo(id)
 	for _, cat in ipairs(self.emojiCategories) do
-		for _, v in ipairs(cat.emojis) do
-			if type(v) == "string" then
-				if id == v then
+		for _, emoji in ipairs(cat.emojis) do
+			if type(emoji) == "string" then
+				if id == emoji then
 					return "materials/icon72/" .. id .. ".png"
 				end
 			else
-				if id == v[1] then
-					return v[2], true
+				if id == emoji.id then
+					return emoji.uri, true
 				end
 			end
 		end
@@ -123,335 +123,23 @@ function Settings:GetEmojiInfo(id)
 end
 
 -- Add a image from the web as a emoji.
--- "index" is optional
-function Settings:AddOnlineEmoji(id, url, index)
+function Settings:AddOnlineEmoji(emoji)
 	local emojis = self.emojiCategories[1].emojis
 
-	index = index and math.Clamp(index, 1, #emojis + 1) or #emojis + 1
-	emojis[index] = { id, url }
+	table.insert(
+		emojis,
+		{ id = emoji.id, uri = emoji.uri, numericId = emoji.numericId }
+	)
 end
 
 function Settings:ClearCustomEmojis()
 	self.emojiCategories[1].emojis = {}
 end
 
-function Settings:ShowServerEmojisPanel()
-	chat.Close()
-
-	local pnl = vgui.Create("DFrame")
-	pnl:SetSize(600, 400)
-	pnl:SetTitle("Server Emojis")
-	pnl:ShowCloseButton(true)
-	pnl:SetDeleteOnClose(true)
-	pnl:Center()
-	pnl:MakePopup()
-
-	local emojis = table.Copy(self.emojiCategories[1].emojis)
-	local refreshListFunc
-
-	local scrollEmojis = vgui.Create("DScrollPanel", pnl)
-	scrollEmojis:Dock(FILL)
-
-	local function removeEmoji(index)
-		table.remove(emojis, index)
-		refreshListFunc()
-	end
-
-	local function updateEmoji(index, id, url)
-		emojis[index][1] = id
-		emojis[index][2] = url
-	end
-
-	local function markEntryAsInvalid(entry, reason)
-		entry._invalidReason = reason
-		entry:SetBGColor(Color(120, 20, 20, 255))
-		entry:SetPaintBackgroundEnabled(true)
-	end
-
-	local function markEntryAsValid(entry)
-		entry._invalidReason = nil
-		entry:SetPaintBackgroundEnabled(false)
-	end
-
-	local function findEmojiIndexById(id)
-		for k, v in ipairs(emojis) do
-			if v[1] == id then
-				return k
-			end
-		end
-	end
-
-	local function isBuiltinEmoji(id)
-		local existingId, isOnline = self:GetEmojiInfo(id)
-		if existingId then
-			return not isOnline
-		end
-	end
-
-	local function addListItem(index, id, url, scroll)
-		if index == 1 then
-			-- remove "no emojis yet"
-			scrollEmojis:Clear()
-		end
-
-		local item = scrollEmojis:Add("DPanel")
-		item:Dock(TOP)
-		item:DockMargin(0, 2, 0, 2)
-		item:DockPadding(2, 2, 2, 2)
-
-		local lblIndex = vgui.Create("DLabel", item)
-		lblIndex:SetText(index)
-		lblIndex:SizeToContents()
-		lblIndex:Dock(LEFT)
-		lblIndex:DockMargin(2, 0, 4, 0)
-
-		local editId = vgui.Create("DTextEntry", item)
-		editId:SetWide(100)
-		editId:Dock(LEFT)
-		editId:SetHistoryEnabled(false)
-		editId:SetMultiline(false)
-		editId:SetMaximumCharCount(32)
-		editId:SetUpdateOnType(true)
-		editId:SetPlaceholderText("<emoji id>")
-
-		editId.OnValueChange = function(s, value)
-			local newId = string.Trim(value)
-			local existingIndex = findEmojiIndexById(newId)
-
-			if string.len(newId) == 0 then
-				markEntryAsInvalid(s, "The ID is empty")
-			elseif string.find(newId, "[^%w_%-]") then
-				markEntryAsInvalid(
-					s,
-					"Only _, -, characters between 0-9 and A-Z are allowed"
-				)
-			elseif existingIndex and existingIndex ~= index then
-				markEntryAsInvalid(
-					s,
-					"Emoji #" .. existingIndex .. " has the same ID"
-				)
-			elseif isBuiltinEmoji(newId) then
-				markEntryAsInvalid(
-					s,
-					'The ID "' .. newId .. '" is reserved for a builtin emoji'
-				)
-			else
-				markEntryAsValid(s)
-			end
-
-			updateEmoji(index, newId, emojis[index][2])
-		end
-
-		local editURL = vgui.Create("DTextEntry", item)
-		editURL:Dock(FILL)
-		editURL:DockMargin(4, 0, 4, 0)
-		editURL:SetHistoryEnabled(false)
-		editURL:SetMultiline(false)
-		editURL:SetMaximumCharCount(256)
-		editURL:SetUpdateOnType(true)
-		editURL:SetPlaceholderText("<link to a image>")
-		editURL._branchWarning = true
-
-		editURL.OnValueChange = function(s, value)
-			local newURL = string.Trim(value)
-
-			if string.len(newURL) == 0 then
-				markEntryAsInvalid(s, "The URL is empty")
-			else
-				if
-					not s._branchWarning
-					and BRANCH == "unknown"
-					and newURL:sub(1, 5) == "https"
-				then
-					s._branchWarning = true
-					Derma_Message(
-						"Some websites using the TLS protocol (https) will not work without the Chromium beta for Garry's Mod.",
-						"Warning",
-						"OK"
-					)
-				end
-
-				markEntryAsValid(s)
-			end
-
-			updateEmoji(index, emojis[index][1], newURL)
-		end
-
-		timer.Simple(0, function()
-			editId:SetValue(id)
-			editURL:SetValue(url)
-
-			-- we only want to show branch warnings
-			-- when the user edits this field
-			editURL._branchWarning = nil
-		end)
-
-		local btnRemove = vgui.Create("DButton", item)
-		btnRemove:SetIcon("icon16/cancel.png")
-		btnRemove:SetTooltip("Remove")
-		btnRemove:SetText("")
-		btnRemove:SetWide(24)
-		btnRemove:Dock(RIGHT)
-
-		btnRemove.DoClick = function()
-			removeEmoji(index)
-		end
-
-		emojis[index][3] = editId
-		emojis[index][4] = editURL
-
-		if scroll then
-			scrollEmojis:ScrollToChild(item)
-		end
-	end
-
-	refreshListFunc = function()
-		scrollEmojis:Clear()
-
-		if #emojis == 0 then
-			local item = scrollEmojis:Add("DLabel")
-			item:Dock(TOP)
-			item:SetText("No emojis yet.")
-			item:SetContentAlignment(5)
-			item:DockMargin(4, 4, 4, 4)
-			item:DockPadding(2, 2, 2, 2)
-			return
-		end
-
-		for index, v in ipairs(emojis) do
-			addListItem(index, v[1], v[2])
-		end
-	end
-
-	refreshListFunc()
-
-	local pnlOptions = vgui.Create("DPanel", pnl)
-	pnlOptions:Dock(BOTTOM)
-
-	local btnAdd = vgui.Create("DButton", pnlOptions)
-	btnAdd:SetIcon("icon16/add.png")
-	btnAdd:SetText(" Add")
-	btnAdd:SetWide(100)
-	btnAdd:Dock(LEFT)
-
-	btnAdd.DoClick = function()
-		local newIndex = #emojis + 1
-		local newId = "emoji-" .. newIndex
-
-		table.insert(emojis, { newId, "" })
-		addListItem(newIndex, newId, "", true)
-	end
-
-	local btnAddSilk = vgui.Create("DButton", pnlOptions)
-	btnAddSilk:SetIcon("icon16/emoticon_evilgrin.png")
-	btnAddSilk:SetText(" Add Silkicon")
-	btnAddSilk:SetTooltip("Add one of the icons bundled with Garry's Mod")
-	btnAddSilk:SetWide(95)
-	btnAddSilk:Dock(LEFT)
-
-	local silkPanel
-
-	pnl.OnClose = function()
-		if IsValid(silkPanel) then
-			silkPanel:Close()
-		end
-	end
-
-	btnAddSilk.DoClick = function()
-		if IsValid(silkPanel) then
-			silkPanel:MakePopup()
-			return
-		end
-
-		silkPanel = vgui.Create("DFrame")
-		silkPanel:SetSize(335, 200)
-		silkPanel:SetTitle("Add Silkicon")
-		silkPanel:Center()
-		silkPanel:MakePopup()
-
-		local iconBrowser = vgui.Create("DIconBrowser", silkPanel)
-		iconBrowser:Dock(FILL)
-
-		iconBrowser.OnChange = function(s)
-			local iconPath = s:GetSelectedIcon()
-
-			local newIndex = #emojis + 1
-			local newId = string.GetFileFromFilename(iconPath):sub(1, -5)
-			local newUrl = "asset://garrysmod/materials/" .. iconPath
-
-			table.insert(emojis, { newId, newUrl })
-			addListItem(newIndex, newId, newUrl, true)
-
-			silkPanel:Close()
-		end
-
-		local editFilter = vgui.Create("DTextEntry", silkPanel)
-		editFilter:SetHistoryEnabled(false)
-		editFilter:SetMultiline(false)
-		editFilter:SetMaximumCharCount(50)
-		editFilter:SetUpdateOnType(true)
-		editFilter:SetPlaceholderText("<search>")
-		editFilter:Dock(BOTTOM)
-
-		editFilter.OnValueChange = function(_, value)
-			iconBrowser:FilterByText(string.Trim(value))
-		end
-	end
-
-	local btnApply = vgui.Create("DButton", pnlOptions)
-	btnApply:SetIcon("icon16/accept.png")
-	btnApply:SetText(" Apply")
-	btnApply:Dock(RIGHT)
-
-	btnApply.DoClick = function()
-		local data = {}
-
-		for k, v in ipairs(emojis) do
-			local invalidReason = v[3]._invalidReason or v[4]._invalidReason
-
-			if invalidReason then
-				Derma_Message(
-					"Invalid emoji #" .. k .. ": " .. invalidReason,
-					"Invalid Emoji",
-					"OK"
-				)
-				return
-			end
-
-			data[k] = { v[1], v[2] }
-		end
-
-		local action = (#data > 0) and "set the" or "remove all"
-
-		data = (#data > 0) and util.TableToJSON(data) or ""
-
-		Derma_Query(
-			"This action will "
-				.. action
-				.. " custom emojis for this server.\nAre you sure?",
-			"Set Custom Emojis",
-			"Yes",
-			function()
-				net.Start("schat.set_emojis", false)
-				net.WriteString(data)
-				net.SendToServer()
-
-				pnl:Close()
-			end,
-			"No"
-		)
-	end
-end
-
 Settings.emojiCategories = {
 	{
 		category = "Custom",
-		emojis = {
-			{
-				"rainbowplz",
-				"https://emoji.gg/assets/emoji/1908_RainbowPls.gif",
-			},
-		},
+		emojis = {},
 	},
 	{
 		category = "People",

--- a/lua/schat/sv_main.lua
+++ b/lua/schat/sv_main.lua
@@ -206,6 +206,14 @@ function Settings:SetChatTags(data, admin)
 	self:Save()
 end
 
+function Settings:GetEmojiInfo(id)
+	for _, emoji in ipairs(self.emojiData) do
+		if id == emoji.id then
+			return emoji, true
+		end
+	end
+end
+
 net.Receive("schat.set_theme", function(_, ply)
 	if SChat:CanSetServerTheme(ply) then
 		local themeData = Settings:Unserialize(net.ReadString())

--- a/lua/schat/sv_main.lua
+++ b/lua/schat/sv_main.lua
@@ -215,15 +215,6 @@ net.Receive("schat.set_theme", function(_, ply)
 	end
 end)
 
-net.Receive("schat.set_emojis", function(_, ply)
-	if SChat:CanSetServerEmojis(ply) then
-		local emojiData = Settings:Unserialize(net.ReadString())
-		Settings:SetEmojis(emojiData, ply:Nick())
-	else
-		ply:ChatPrint("SChat: You cannot change the server emojis.")
-	end
-end)
-
 net.Receive("schat.set_tags", function(_, ply)
 	if SChat:CanSetChatTags(ply) then
 		local tagsData = Settings:Unserialize(net.ReadString())


### PR DESCRIPTION
## Ticket Link

[GMOD-47](https://taservers.atlassian.net/browse/GMOD-47)

## Changes

- Removes the custom emotes setting pane and related client -> server emote upload code
- Completely refactors how custom emotes are represented in code
  - Previously they were arrays, which are unreadable in consuming code (`emote[1]` instead of `emote.id`)
- Adds support for both `<:name:id>` and `<a:name:id>` Discord emote formats to
  - The message parser
  - JS block builders
  - Emote palette
- Adds an additional emote normalisation step to the message cleaning function
  - This replaces e.g. `:trollhd:` with `<:trollhd:id>` and `:some_animated_emote:` with `<a:some_animated_emote:id>`, while leaving `:some_unicode_emoji:` as-is
- Removes the hardcoded anime custom emote

## Impact

- Provides full integration with Discord for custom emotes
- Improves the quality of the codebase (marginally)

## Testing

todo

[GMOD-47]: https://taservers.atlassian.net/browse/GMOD-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ